### PR TITLE
force main thread for Observable, Subject and LivecycleViewModel

### DIFF
--- a/stencils/LifecycleViewModel.stencil
+++ b/stencils/LifecycleViewModel.stencil
@@ -7,12 +7,19 @@ class LifecycleViewModel<VM: BaseViewModel> {
     let containerView: ContainerView?
 
     init(_ viewModel: VM, containerView: ContainerView? = nil) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         self.viewModel = viewModel
         self.containerView = containerView
     }
 
     deinit {
-        viewModel.clear()
+        if Thread.current.isMainThread {
+            viewModel.clear()
+        } else {
+            DispatchQueue.main.sync {
+                viewModel.clear()
+            }
+        }
     }
 
     func lifecycleView<V: View>(view: (VM) -> V) -> some View {

--- a/stencils/LifecycleViewModel.stencil
+++ b/stencils/LifecycleViewModel.stencil
@@ -16,8 +16,9 @@ class LifecycleViewModel<VM: BaseViewModel> {
         if Thread.current.isMainThread {
             viewModel.clear()
         } else {
-            DispatchQueue.main.sync {
-                viewModel.clear()
+            let vm = viewModel
+            DispatchQueue.main.async {
+                vm.clear()
             }
         }
     }

--- a/stencils/LifecycleViewModel.stencil
+++ b/stencils/LifecycleViewModel.stencil
@@ -13,13 +13,9 @@ class LifecycleViewModel<VM: BaseViewModel> {
     }
 
     deinit {
-        if Thread.current.isMainThread {
-            viewModel.clear()
-        } else {
-            let vm = viewModel
-            DispatchQueue.main.async {
-                vm.clear()
-            }
+        let vm = viewModel
+        DispatchQueue.main.async {
+            vm.clear()
         }
     }
 

--- a/stencils/ListObservable.stencil
+++ b/stencils/ListObservable.stencil
@@ -17,6 +17,7 @@ class ListObservable<Output: Equatable>: ObservableObject {
         animated: Bool = false,
         mapper: @escaping (NSArray) -> [Output] = ListMapper.to
     ) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         input = observable.currentOrNull
         if input != nil {
             value = mapper(input!)
@@ -48,7 +49,10 @@ class ListObservable<Output: Equatable>: ObservableObject {
     }
 
     deinit {
-        disposeBag.dispose()
+        let bag = disposeBag
+        DispatchQueue.main.async {
+            bag.dispose()
+        }
     }
 }
 

--- a/stencils/ListSubject.stencil
+++ b/stencils/ListSubject.stencil
@@ -18,6 +18,7 @@ class ListSubject<Output: Equatable>: ObservableObject {
          animated: Bool = false,
          mapper: @escaping (NSArray) -> [Output] = ListMapper.to
     ) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         input = subject.currentOrNull
         if input != nil {
             value = mapper(input!)
@@ -54,7 +55,10 @@ class ListSubject<Output: Equatable>: ObservableObject {
     }
 
     deinit {
-        disposeBag.dispose()
+        let bag = disposeBag
+        DispatchQueue.main.async {
+            bag.dispose()
+        }
     }
 }
 

--- a/stencils/Observable.stencil
+++ b/stencils/Observable.stencil
@@ -60,13 +60,9 @@ class Observable<Input: KotlinObject, Output: Equatable>: ObservableObject {
     }
 
     deinit {
-        if (Thread.current.isMainThread) {
-            disposeBag.dispose()
-        } else {
-            let bag = disposeBag
-            DispatchQueue.main.async {
-                bag.dispose()
-            }
+        let bag = disposeBag
+        DispatchQueue.main.async {
+            bag.dispose()
         }
     }
 }

--- a/stencils/Observable.stencil
+++ b/stencils/Observable.stencil
@@ -63,8 +63,9 @@ class Observable<Input: KotlinObject, Output: Equatable>: ObservableObject {
         if (Thread.current.isMainThread) {
             disposeBag.dispose()
         } else {
-            DispatchQueue.main.sync {
-                disposeBag.dispose()
+            let bag = disposeBag
+            DispatchQueue.main.async {
+                bag.dispose()
             }
         }
     }

--- a/stencils/Observable.stencil
+++ b/stencils/Observable.stencil
@@ -29,6 +29,7 @@ class Observable<Input: KotlinObject, Output: Equatable>: ObservableObject {
         animated: Bool = false,
         mapper: @escaping (Input) -> Output
     ) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         input = observable.currentOrNull
         if input != nil {
             value = mapper(input!)
@@ -59,7 +60,13 @@ class Observable<Input: KotlinObject, Output: Equatable>: ObservableObject {
     }
 
     deinit {
-        disposeBag.dispose()
+        if (Thread.current.isMainThread) {
+            disposeBag.dispose()
+        } else {
+            DispatchQueue.main.sync {
+                disposeBag.dispose()
+            }
+        }
     }
 }
 

--- a/stencils/Subject.stencil
+++ b/stencils/Subject.stencil
@@ -65,8 +65,9 @@ class Subject<Input: KotlinObject, Output: Equatable>: ObservableObject {
         if (Thread.current.isMainThread) {
             disposeBag.dispose()
         } else {
-            DispatchQueue.main.sync {
-                disposeBag.dispose()
+            let bag = disposeBag
+            DispatchQueue.main.async {
+                bag.dispose()
             }
         }
     }

--- a/stencils/Subject.stencil
+++ b/stencils/Subject.stencil
@@ -25,6 +25,7 @@ class Subject<Input: KotlinObject, Output: Equatable>: ObservableObject {
          toMapper: @escaping (Input) -> Output,
          fromMapper: @escaping (Output) -> Input
     ) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         input = subject.currentOrNull
         if input != nil {
             value = toMapper(input!)
@@ -61,7 +62,13 @@ class Subject<Input: KotlinObject, Output: Equatable>: ObservableObject {
     }
 
     deinit {
-        disposeBag.dispose()
+        if (Thread.current.isMainThread) {
+            disposeBag.dispose()
+        } else {
+            DispatchQueue.main.sync {
+                disposeBag.dispose()
+            }
+        }
     }
 }
 

--- a/stencils/Subject.stencil
+++ b/stencils/Subject.stencil
@@ -62,13 +62,9 @@ class Subject<Input: KotlinObject, Output: Equatable>: ObservableObject {
     }
 
     deinit {
-        if (Thread.current.isMainThread) {
-            disposeBag.dispose()
-        } else {
-            let bag = disposeBag
-            DispatchQueue.main.async {
-                bag.dispose()
-            }
+        let bag = disposeBag
+        DispatchQueue.main.async {
+            bag.dispose()
         }
     }
 }

--- a/stencils/UninitializedObservable.stencil
+++ b/stencils/UninitializedObservable.stencil
@@ -25,6 +25,7 @@ class UninitializedObservable<Input: KotlinObject, Output: Equatable>: Observabl
         animated: Bool = false,
         mapper: @escaping (Input?) -> Output?
     ) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         input = observable.currentOrNull
         if input != nil {
             value = mapper(input!)
@@ -53,7 +54,10 @@ class UninitializedObservable<Input: KotlinObject, Output: Equatable>: Observabl
     }
 
     deinit {
-        disposeBag.dispose()
+        let bag = disposeBag
+        DispatchQueue.main.async {
+            bag.dispose()
+        }
     }
 }
 

--- a/stencils/UninitializedSubject.stencil
+++ b/stencils/UninitializedSubject.stencil
@@ -22,6 +22,7 @@ class UninitializedSubject<Input: KotlinObject, Output: Equatable>: ObservableOb
          toMapper: @escaping (Input?) -> Output?,
          fromMapper: @escaping (Output?) -> Input?
     ) {
+        assert(Thread.isMainThread, "Constructor must be called on the main thread, but called on \(Thread.current)")
         input = subject.currentOrNull
         if input != nil {
             value = toMapper(input!)
@@ -65,7 +66,10 @@ class UninitializedSubject<Input: KotlinObject, Output: Equatable>: ObservableOb
     }
 
     deinit {
-        disposeBag.dispose()
+        let bag = disposeBag
+        DispatchQueue.main.async {
+            bag.dispose()
+        }
     }
 }
 


### PR DESCRIPTION
it seems like deinit could be called on any thread, which in turn causes freezing. we are using observers on the main thread only, so I added an assert to enforce that and also added a workaround for deinit called from a background thread