### PR TITLE
Fix a bug where when importing whole sharedFramework we can shadow UI…

### DIFF
--- a/stencils/ContainerView.stencil
+++ b/stencils/ContainerView.stencil
@@ -1,5 +1,7 @@
 import SwiftUI
-import {{ argument.sharedFrameworkName }}
+import class {{ argument.sharedFrameworkName }}.AlertPresenter
+import class {{ argument.sharedFrameworkName }}.HUD
+import class {{ argument.sharedFrameworkName }}.DateTimePickerPresenter
 
 struct ContainerView: UIViewControllerRepresentable {
 

--- a/stencils/KalugaStyledString+SwiftUI.stencil
+++ b/stencils/KalugaStyledString+SwiftUI.stencil
@@ -1,6 +1,7 @@
 {% if argument.includeResources %}
 import SwiftUI
-import {{ argument.sharedFrameworkName }}
+import class {{ argument.sharedFrameworkName }}.KalugaLabel
+import class {{ argument.sharedFrameworkName }}.TextStyleKt
 
 // MARK: - StyledString
 


### PR DESCRIPTION
This PR fixes a bug where when importing the whole sharedFramework we can shadow UIKit declarations.
When restricting imports only to classes we need we can avoid side effects.

Specifically, it seems that sometimes in the header file generated for the shared Kotlin framework there is `UIViewController` type defined without adding `#import <UIKit/UIViewController.h>` which effectively is causing that shared framework declaration shadows the UIKit type.

That leads to errors like:
`KalugaStyledString+SwiftUI.generated.swift:17:16: error: type 'AttributedText' does not conform to protocol 'UIViewRepresentable'`