### PR TITLE
Implemented MappedSimpleSubject

### DIFF
--- a/stencils/Subject.stencil
+++ b/stencils/Subject.stencil
@@ -9,6 +9,7 @@ typealias IntSubject = MappedSubject<KotlinInt, Int, IntMapper>
 typealias FloatSubject = MappedSubject<KotlinFloat, Float, FloatMapper>
 typealias DoubleSubject = MappedSubject<KotlinDouble, Double, DoubleMapper>
 typealias DateSubject = MappedSubject<KalugaDate, Foundation.Date, DateMapper>
+typealias ObjectSimpleSubject<T: KotlinObject> = MappedSimpleSubject<T, T, EmptyMapper<T>>
 
 class Subject<Input: KotlinObject, Output: Any>: ObservableObject {
 
@@ -75,6 +76,23 @@ class MappedSubject<
 >: Subject<Input, Output> where Mapper.Input == Input, Mapper.Output == Output {
 
     init(_ subject: BaseInitializedSubject<Input>, defaultValue: Output = .default(), animated: Bool = false) {
+        super.init(
+            subject,
+            defaultValue: defaultValue,
+            animated: animated,
+            toMapper: Mapper.to,
+            fromMapper: Mapper.from
+        )
+    }
+}
+
+class MappedSimpleSubject<
+    Input: KotlinObject,
+    Output: Any,
+    Mapper: PlatformValueMapper
+>: Subject<Input, Output> where Mapper.Input == Input, Mapper.Output == Output {
+
+    init(_ subject: BaseInitializedSubject<Input>, defaultValue: Output, animated: Bool = false) {
         super.init(
             subject,
             defaultValue: defaultValue,


### PR DESCRIPTION
Implemented `ObjectSimpleSubject` which allows developers to create an instance of `MappedSimpleSubject` without implementing HasDefaultValue protocol, but must provide a default value in init 