### PR TITLE
Changes to make AttributedStrings for SwiftUI work without workarounds

### DIFF
--- a/stencils/KalugaButton+SwiftUI.stencil
+++ b/stencils/KalugaButton+SwiftUI.stencil
@@ -52,7 +52,8 @@ private extension KalugaButton.WithText {
         switch self {
         case let plain as KalugaButton.Plain: Text(plain.text)
                 .textStyle(textStyle)
-        case let styled as KalugaButton.Styled: KalugaLabel.Styled(text: styled.text, style: textStyle).toAttributedText()
+        case let styled as KalugaButton.Styled: Text(styled.text.toAttributedString())
+                .textStyle(textStyle)
         default: fatalError("Unknown KalugaButton.WithText \(self)")
         }
     }
@@ -92,20 +93,40 @@ private struct KalugaButtonView: View {
     let buttonFrame: ButtonFrame
     let isEnabled: Bool
     let isPressed: Bool
-    
-    
+
     var body: some View {
         switch button {
         case let withText as KalugaButton.WithText:
             switch withText.style {
-            case let withImageAndText as KalugaButtonStyleWithImageAndText: KalugaButtonStyleWithImageAndTextView(button: withText, style: withImageAndText, buttonFrame: buttonFrame, isEnabled: isEnabled, isPressed: isPressed)
-            case is KalugaButtonStyleTextOnly: KalugaButtonStyleTextOnlyView(button: withText, buttonFrame: buttonFrame, isEnabled: isEnabled, isPressed: isPressed)
+            case let withImageAndText as KalugaButtonStyleWithImageAndText: KalugaButtonStyleWithImageAndTextView(
+                button: withText,
+                style: withImageAndText,
+                buttonFrame: buttonFrame,
+                isEnabled: isEnabled,
+                isPressed: isPressed
+            )
+            case is KalugaButtonStyleTextOnly: KalugaButtonStyleTextOnlyView(
+                button: withText,
+                buttonFrame: buttonFrame,
+                isEnabled: isEnabled,
+                isPressed: isPressed
+            )
             default: fatalError("Unknown KalugaButtonStyle.WithText \(withText.style)")
             }
         case let withoutText as KalugaButton.WithoutText:
             switch withoutText.style {
-            case let imageOnly as KalugaButtonStyleImageOnly: KalugaButtonStyleImageOnlyView(style: imageOnly, buttonFrame: buttonFrame, isEnabled: isEnabled, isPressed: isPressed)
-            case let withoutContent as KalugaButtonStyleWithoutContent: KalugaButtonStyleWithoutContentView(style: withoutContent, buttonFrame: buttonFrame, isEnabled: isEnabled, isPressed: isPressed)
+            case let imageOnly as KalugaButtonStyleImageOnly: KalugaButtonStyleImageOnlyView(
+                style: imageOnly,
+                buttonFrame: buttonFrame,
+                isEnabled: isEnabled,
+                isPressed: isPressed
+            )
+            case let withoutContent as KalugaButtonStyleWithoutContent: KalugaButtonStyleWithoutContentView(
+                style: withoutContent,
+                buttonFrame: buttonFrame,
+                isEnabled: isEnabled,
+                isPressed: isPressed
+            )
             default: fatalError("Unknown KalugaButtonStyle.WithoutText \(withoutText.style)")
             }
         default: fatalError("Unknown KalugaButton \(button)")

--- a/stencils/KalugaLabel+SwiftUI.stencil
+++ b/stencils/KalugaLabel+SwiftUI.stencil
@@ -56,7 +56,8 @@ private extension KalugaLabel {
     }
     private func makeStyledLabel(label: KalugaLabel.Styled) -> AnyView {
         return AnyView(
-            label.toAttributedText()
+            Text(label.text.toAttributedString())
+                .textStyle(style)
         )
     }
 }

--- a/stencils/KalugaStyledString+SwiftUI.stencil
+++ b/stencils/KalugaStyledString+SwiftUI.stencil
@@ -1,49 +1,33 @@
 {% if argument.includeResources %}
 import SwiftUI
-import class {{ argument.sharedFrameworkName }}.KalugaLabel
+import class {{ argument.sharedFrameworkName }}.StyledString
 import class {{ argument.sharedFrameworkName }}.TextStyleKt
 
 // MARK: - StyledString
 
-extension KalugaLabel.Styled {
-    func toAttributedText() -> some View {
-        AttributedText(styledLabel: self)
-    }
-}
+extension StyledString {
+    func toAttributedString() -> AttributedString {
+            var attributedString = AttributedString(attributeString)
 
-// MARK: - AttributedText
-
-private struct AttributedText: View {
-
-    var styledLabel: KalugaLabel.Styled
-
-    @SwiftUI.State private var height: CGFloat = .zero
-
-    var body: some View {
-        InternalAttributedText(styledLabel: styledLabel, dynamicHeight: $height)
-            .frame(minHeight: height)
-    }
-
-    struct InternalAttributedText: UIViewRepresentable {
-        var styledLabel: KalugaLabel.Styled
-        @Binding var dynamicHeight: CGFloat
-
-        func makeUIView(context: Context) -> UILabel {
-            let label = UILabel()
-            label.lineBreakMode = .byClipping
-            label.numberOfLines = 0
-            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-            label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-            return label
-        }
-
-        func updateUIView(_ uiView: UILabel, context: Context) {
-            TextStyleKt.bindLabel(uiView, label: styledLabel)
-
-            DispatchQueue.main.async {
-                dynamicHeight = uiView.sizeThatFits(CGSize(width: uiView.bounds.width, height: CGFloat.greatestFiniteMagnitude)).height
+            let ranges: [Range<AttributedString.Index>] = attributedString.runs.compactMap { run in
+                if run.attributes.link != nil {
+                    run.range
+                } else {
+                    nil
+                }
             }
-        }
+            ranges.forEach { range in
+                var container = AttributeContainer()
+                if let linkStyle = linkStyle {
+                    container = container.foregroundColor(linkStyle.color.swiftUI)
+                    if linkStyle.isUnderlined {
+                        container = container.underlineStyle(.single)
+                    }
+                }
+
+                attributedString[range].mergeAttributes(container)
+            }
+            return attributedString
     }
 }
 {% endif %}


### PR DESCRIPTION
SwiftUI can map NSAttributedString to AttributedString (Swift) nowadays, so we no longer need to use the workaround. This should ensure all attributes work as intended, including links.